### PR TITLE
feat: add support for dynamic icons (lucide/dynamic)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "payload": "^3.0.0",
     "react": "^18.0.0 || ^19.0.0"
   },
+  "dependencies": {
+    "lucide-react": ">=0.300.0"
+  },
   "devDependencies": {
     "@payloadcms/translations": "^3.0.0",
     "@payloadcms/ui": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      lucide-react:
+        specifier: '>=0.300.0'
+        version: 0.555.0(react@19.2.0)
     devDependencies:
       '@payloadcms/translations':
         specifier: ^3.0.0
@@ -20,9 +24,6 @@ importers:
       esbuild-sass-plugin:
         specifier: ^3.3.1
         version: 3.3.1(esbuild@0.27.0)(sass-embedded@1.93.3)
-      lucide-react:
-        specifier: '>=0.300.0'
-        version: 0.555.0(react@19.2.0)
       next:
         specifier: ^15.0.0
         version: 15.5.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.94.2)

--- a/src/components/CustomNav/NavClientWrapper.tsx
+++ b/src/components/CustomNav/NavClientWrapper.tsx
@@ -56,7 +56,6 @@ export const NavClientWrapper: React.FC<NavClientWrapperProps> = (props) => {
     enablePinning: navConfig.enablePinning,
     pinnedStorage: navConfig.pinnedStorage,
     cssVariables: navConfig.cssVariables,
-    cu
   }
 
   return (

--- a/src/components/CustomNav/NavClientWrapper.tsx
+++ b/src/components/CustomNav/NavClientWrapper.tsx
@@ -56,6 +56,7 @@ export const NavClientWrapper: React.FC<NavClientWrapperProps> = (props) => {
     enablePinning: navConfig.enablePinning,
     pinnedStorage: navConfig.pinnedStorage,
     cssVariables: navConfig.cssVariables,
+    cu
   }
 
   return (

--- a/src/components/CustomNav/index.client.tsx
+++ b/src/components/CustomNav/index.client.tsx
@@ -7,20 +7,14 @@ import { StyleInjector } from './StyleInjector'
 import { NavContent } from './NavContent'
 import { NavConfigProvider } from '../NavContext'
 import { DEFAULT_ICONS } from '../../defaults'
-import type { NavEntity, NavConfigContextValue, CustomLink } from '../../types'
+import type { NavEntity, NavConfigContextValue, CustomLink, IconComponentSerializable, SerializableNavConfig } from '../../types'
 
 interface NavGroupData {
   label: string
   entities: NavEntity[]
 }
 
-interface SerializableNavConfig {
-  classPrefix: string
-  enablePinning: boolean
-  pinnedStorage: 'preferences' | 'localStorage'
-  cssVariables: Record<string, string>
-  customLinks: CustomLink[]
-}
+
 
 interface NavClientWrapperProps {
   classPrefix?: string
@@ -53,6 +47,7 @@ export const CustomNavClient: React.FC<NavClientWrapperProps> = (props) => {
   // Build full config with icons (which can't be serialized from server)
   const fullConfig: NavConfigContextValue = {
     icons: DEFAULT_ICONS,
+    customIcons: navConfig.icons || {},
     classPrefix: navConfig.classPrefix,
     enablePinning: navConfig.enablePinning,
     pinnedStorage: navConfig.pinnedStorage,

--- a/src/components/CustomNav/index.tsx
+++ b/src/components/CustomNav/index.tsx
@@ -13,7 +13,7 @@ import { CustomNavClient } from 'payload-sidebar-plugin/components'
 import { sortGroups } from '../../utils/sortGroups'
 import { DEFAULT_GROUP_ORDER, DEFAULT_BADGE_COLORS } from '../../defaults'
 import { getPluginOptions, type SerializableCustomLink } from '../../plugin/index'
-import type { NavEntity, NavGroup, CustomGroup } from '../../types'
+import type { NavEntity, NavGroup, CustomGroup, SerializableNavConfig } from '../../types'
 
 export type CustomNavProps = {
   req?: PayloadRequest
@@ -224,6 +224,7 @@ export async function CustomNav(props: CustomNavProps): Promise<React.ReactEleme
   const cssVariables = { ...DEFAULT_BADGE_COLORS, ...pluginOptions.cssVariables }
   const customLinks = pluginOptions.customLinks ?? []
   const customGroups = pluginOptions.customGroups ?? []
+  const customIcons = pluginOptions.icons ?? {}
 
   const {
     admin: {
@@ -279,12 +280,13 @@ export async function CustomNav(props: CustomNavProps): Promise<React.ReactEleme
   const navPreferences = await getNavPrefs(req)
 
   // Serializable config for client components (no functions, no React components)
-  const navConfig = {
+  const navConfig:SerializableNavConfig = {
     classPrefix,
     enablePinning,
     pinnedStorage,
     cssVariables,
     customLinks,
+    icons: customIcons, // A map of string keys to icon names
   }
 
   const LogoutComponent = RenderServerComponent({

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -36,6 +36,9 @@ export const getPluginOptions = (): PayloadSidebarOptions => globalPluginOptions
  * })
  * ```
  */
+/**
+ * @deprecated This file is not using anymore, actual plugin export in src/plugin/index.ts
+ */
 export const payloadSidebar = (options: PayloadSidebarOptions = {}) => {
   // Store options globally for server component access
   globalPluginOptions = options

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'payload'
-import type { CustomLink, CustomGroup, IconComponent } from '../types'
+import type { CustomLink, CustomGroup, IconComponentSerializable } from '../types'
 
 /**
  * Serializable custom link (icon as string key)
@@ -23,9 +23,9 @@ export interface PayloadSidebarPluginOptions {
    */
   groupOrder?: Record<string, number>
   /**
-   * Custom icons for collections/globals
+   * Custom icons for collections/globals, using lucide-react/dynamic icon names.
    */
-  icons?: Record<string, IconComponent>
+  icons?: Record<string, IconComponentSerializable>
 
   /**
    * Custom navigation links
@@ -85,6 +85,7 @@ export interface SerializablePluginOptions {
   pinnedStorage?: 'preferences' | 'localStorage'
   classPrefix?: string
   cssVariables?: Record<string, string>
+  icons?: Record<string, IconComponentSerializable>
 }
 
 /**
@@ -174,6 +175,8 @@ export const payloadSidebar = (options: PayloadSidebarPluginOptions = {}) => {
       pinnedStorage: options.pinnedStorage,
       classPrefix: options.classPrefix,
       cssVariables: options.cssVariables,
+      //Icons are serializable now, using Dynamic icons from lucide
+      icons: options.icons,
     }
 
     config.custom = config.custom || {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-react'
+import { IconName } from 'lucide-react/dynamic'
 
 // ============================================================================
 // Badge Types
@@ -164,9 +165,14 @@ export interface NavGroup {
 // ============================================================================
 
 /**
- * Icon component type - Lucide icon or custom component
+ * Icon component  LucideIcon component or custom React component
  */
 export type IconComponent = LucideIcon | React.ComponentType<{ size?: number; className?: string }>
+
+/**
+ * Type for config icons, which must be serializable, will be used with DynamicIcon from 'lucide-react/dynamic'
+ */
+export type IconComponentSerializable = IconName
 
 /**
  * Main plugin configuration options
@@ -185,7 +191,7 @@ export interface PayloadSidebarOptions {
    * Merge với default icons
    * @example { 'my-collection': MyIcon }
    */
-  icons?: Record<string, IconComponent>
+  icons?: Record<string, IconComponentSerializable>
 
   /**
    * Custom navigation links
@@ -279,5 +285,15 @@ export interface NavConfigContextValue {
   pinnedStorage: 'preferences' | 'localStorage'
   cssVariables: Record<string, string>
   customLinks: CustomLink[]
+  customIcons?: Record<string, IconComponentSerializable>
   onPinChange?: (item: PinnedItem, action: 'pin' | 'unpin') => void
+}
+
+export interface SerializableNavConfig {
+  classPrefix: string
+  enablePinning: boolean
+  pinnedStorage: 'preferences' | 'localStorage'
+  cssVariables: Record<string, string>
+  customLinks: CustomLink[]
+  icons?: Record<string, IconComponentSerializable>
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,7 +14,7 @@ const external = [
   '@payloadcms/ui/elements/RenderServerComponent',
   '@payloadcms/ui/shared',
   '@payloadcms/translations',
-  'lucide-react',
+  /^lucide-react/,  // Match lucide-react and all sub-paths
 ]
 
 export default defineConfig([


### PR DESCRIPTION
 ## Add Dynamic Icon Support

  Adds support for dynamic icons using `lucide-react/dynamic` to enable runtime icon loading by name.

  ### Changes
  - ✨ Support dynamic icons via `lucide-react/dynamic` for custom collection/global icons
  - 🔧 Fix icon resolution logic to prioritize `customIcons` config
  - 📦 Add `lucide-react` as dependency (not just peer) for better module resolution
  - 🛠️ Update tsup config to externalize all lucide-react sub-paths (`/^lucide-react/`)

  ### Why
  - Icons can now be specified by string name in plugin config (serializable from server to client) for each collection/global slug

  ### Example
  ```ts
  payloadSidebar({
    icons: {
      'posts': 'book',
      'videos': 'clapperboard',
    }
  })